### PR TITLE
feat(firmware): add USB remote wakeup support

### DIFF
--- a/firmware/src/forwarder.cc
+++ b/firmware/src/forwarder.cc
@@ -9,8 +9,16 @@
 #define FORWARDER_RX_PIN 9
 
 bool led_state = false;
+static bool wakeup_sent = false;
 
 void serial_callback(const uint8_t* data, uint16_t len) {
+    if (tud_suspended()) {
+        if (!wakeup_sent) {
+            tud_remote_wakeup();
+            wakeup_sent = true;
+        }
+        return;
+    }
     tud_hid_report(data[0], data + 1, len - 1);
     board_led_write(led_state);
     led_state = !led_state;
@@ -30,6 +38,9 @@ int main() {
     while (true) {
         serial_read(serial_callback, FORWARDER_UART);
         tud_task();
+        if (!tud_suspended()) {
+            wakeup_sent = false;
+        }
     }
 
     return 0;

--- a/firmware/src/remapper.cc
+++ b/firmware/src/remapper.cc
@@ -650,6 +650,8 @@ int main() {
 
     next_print = time_us_64() + 1000000;
 
+    static bool wakeup_sent = false;
+
     while (true) {
         if (read_report()) {
             process_mapping(get_and_clear_tick_pending());
@@ -660,6 +662,12 @@ int main() {
                 process_mapping(true);
             }
             send_report();
+        } else if (tud_suspended() && or_items > 0 && !wakeup_sent) {
+            tud_remote_wakeup();
+            wakeup_sent = true;
+        }
+        if (!tud_suspended()) {
+            wakeup_sent = false;
         }
 
         if (their_descriptor_updated) {

--- a/firmware/src/tinyusb_stuff.cc
+++ b/firmware/src/tinyusb_stuff.cc
@@ -58,7 +58,7 @@ tusb_desc_device_t const desc_device = {
 
 uint8_t const desc_configuration[] = {
     // Config number, interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, 1, 0, CONFIG_TOTAL_LEN, 0, 100),
+    TUD_CONFIG_DESCRIPTOR(1, 1, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
     // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
     TUD_HID_DESCRIPTOR(0, 0, HID_ITF_PROTOCOL_NONE, our_report_descriptor_length, EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 1)


### PR DESCRIPTION
This change allows the screen-hopper to wake connected machines from sleep using just keyboard/mouse activity. Without it, as soon as my Macs enter sleep the only way to get them out again is either to unplug/replug the screen-hopper or wake via opening the lid.

Sets the remote wakeup supported attribute on the USB device, and sends the wakeup command whenever activity arrives while the device is in suspended state.